### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: <h1>CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/beingxaman/test/security/code-scanning/1](https://github.com/beingxaman/test/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily checks out the repository and runs scripts, it only requires `contents: read` permissions. This will restrict the workflow's access to repository contents to read-only, minimizing the risk of unintended modifications.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This ensures that all jobs in the workflow inherit the same minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
